### PR TITLE
Fix for unnecessary ClassCastException when logging is turned way up

### DIFF
--- a/rx-jersey-core/src/main/java/net/winterly/rxjersey/server/RxGenericBodyWriter.java
+++ b/rx-jersey-core/src/main/java/net/winterly/rxjersey/server/RxGenericBodyWriter.java
@@ -39,11 +39,10 @@ public abstract class RxGenericBodyWriter implements MessageBodyWriter<Object> {
     }
 
     /**
-     * @param genericType type to process
+     * @param parameterizedType type to process
      * @return the raw type without generics
      */
-    private static Class raw(Type genericType) {
-        final ParameterizedType parameterizedType = (ParameterizedType) genericType;
+    private static Class raw(ParameterizedType parameterizedType) {
         return (Class) parameterizedType.getRawType();
     }
 
@@ -58,7 +57,9 @@ public abstract class RxGenericBodyWriter implements MessageBodyWriter<Object> {
 
     @Override
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        Class rawType = raw(genericType);
+        if(!(genericType instanceof ParameterizedType))
+            return false;
+        Class rawType = raw((ParameterizedType)genericType);
         return allowedTypes.contains(rawType);
     }
 


### PR DESCRIPTION
When we turned logging way up (up to `FINEST`), we saw the following message pop up:

```
java.lang.ClassCastException: java.lang.Class cannot be cast to java.lang.reflect.ParameterizedType
	at net.winterly.rxjersey.server.RxGenericBodyWriter.raw(RxGenericBodyWriter.java:46)
	at net.winterly.rxjersey.server.RxGenericBodyWriter.isWriteable(RxGenericBodyWriter.java:61)
	at org.glassfish.jersey.message.internal.MessageBodyFactory.isWriteable(MessageBodyFactory.java:1160)
	at org.glassfish.jersey.message.WriterModel.isWriteable(WriterModel.java:86)
	at org.glassfish.jersey.message.internal.MessageBodyFactory._getMessageBodyWriter(MessageBodyFactory.java:798)
	at org.glassfish.jersey.message.internal.MessageBodyFactory.getMessageBodyWriter(MessageBodyFactory.java:756)
	at org.glassfish.jersey.message.internal.MessageBodyFactory.getMessageBodyWriter(MessageBodyFactory.java:735)
	at net.winterly.rxjersey.server.RxGenericBodyWriter.writeTo(RxGenericBodyWriter.java:76)
```

This is because of a cast to `ParametrizedType` which isn't preceded by an if statement. It doesn't pose a problem, but the log message is a little annoying.