### PR TITLE
fix WebResourceFactory support for Sub Resources

### DIFF
--- a/core-client/src/main/java/net/winterly/rxjersey/client/WebResourceFactory.java
+++ b/core-client/src/main/java/net/winterly/rxjersey/client/WebResourceFactory.java
@@ -210,7 +210,7 @@ public final class WebResourceFactory implements InvocationHandler {
 
         if (httpMethod == null) {
             // the method is a subresource locator
-            return WebResourceFactory.newResource(responseType, newTarget, true, headers, cookies, form, null);
+            return WebResourceFactory.newResource(responseType, newTarget, true, headers, cookies, form, invoker);
         }
 
         // accepted media types

--- a/rxjava2-client/src/test/java/RxJerseyTest.java
+++ b/rxjava2-client/src/test/java/RxJerseyTest.java
@@ -108,6 +108,32 @@ public class RxJerseyTest extends JerseyTest {
         public String error() {
             throw new BadRequestException();
         }
+
+        @Path("subresource/{id}")
+        public ServerSubResource subResource(@PathParam("id") String id) {
+            return new ServerSubResource(id);
+        }
+    }
+
+    public static class ServerSubResource {
+
+        private final String id;
+
+        public ServerSubResource(String id) {
+            this.id = id;
+        }
+
+        @GET
+        public String getId() {
+            return id;
+        }
+
+        @GET
+        @Path("attribute")
+        public String attribute() {
+            return "attribute";
+        }
+
     }
 
     public static class Entity {

--- a/rxjava2-client/src/test/java/SubResourceTest.java
+++ b/rxjava2-client/src/test/java/SubResourceTest.java
@@ -1,0 +1,46 @@
+import static org.junit.Assert.assertEquals;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import org.junit.Test;
+
+import io.reactivex.Single;
+
+public class SubResourceTest extends RxJerseyTest {
+
+    @Test
+    public void shouldReturnContentFromSubResourceWithoutPath() {
+        SingleResource resource = resource(SingleResource.class);
+        String subResourceId = resource.getSubResource("someId").getId().blockingGet();
+
+        assertEquals("someId", subResourceId);
+    }
+
+    @Test
+    public void shouldReturnContentFromSubResourcePath() {
+        SingleResource resource = resource(SingleResource.class);
+        String attribute = resource.getSubResource("someId").getAttribute().blockingGet();
+
+        assertEquals("attribute", attribute);
+    }
+
+    @Path("/endpoint")
+    public interface SingleResource {
+
+        @Path("subresource/{id}")
+        SingleSubResource getSubResource(@PathParam("id") String id);
+    }
+
+    public interface SingleSubResource {
+
+        @GET
+        Single<String> getId();
+
+        @GET
+        @Path("attribute")
+        Single<String> getAttribute();
+
+    }
+}


### PR DESCRIPTION
This PR fixes support for Sub Resources in WebResourceFactory.

Side note, is this Issue dead in the water? [#3187](https://github.com/eclipse-ee4j/jersey/issues/3187)