### PR TITLE
Support javax.ws.rs.core.Response values wrapped in Rx containers

### DIFF
--- a/rxjava2-client/src/main/java/net/winterly/rxjersey/client/rxjava2/FlowableClientMethodInvoker.java
+++ b/rxjava2-client/src/main/java/net/winterly/rxjersey/client/rxjava2/FlowableClientMethodInvoker.java
@@ -7,6 +7,7 @@ import org.glassfish.jersey.client.rx.rxjava2.RxFlowableInvoker;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.GenericType;
+import java.lang.reflect.ParameterizedType;
 import java.util.HashMap;
 import java.util.function.Function;
 
@@ -24,18 +25,42 @@ public class FlowableClientMethodInvoker implements ClientMethodInvoker<Object> 
 
     @Override
     public <T> Object method(Invocation.Builder builder, String name, GenericType<T> responseType) {
-        Flowable<T> flowable = builder.rx(RxFlowableInvoker.class).method(name, responseType);
+        GenericType<?> responseValueType = getValueTypeIfPossible(responseType);
+        Flowable<?> flowable = builder.rx(RxFlowableInvoker.class).method(name, responseValueType);
         return convert(flowable, responseType);
     }
 
     @Override
     public <T> Object method(Invocation.Builder builder, String name, Entity<?> entity, GenericType<T> responseType) {
-        Flowable<T> flowable = builder.rx(RxFlowableInvoker.class).method(name, entity, responseType);
+        GenericType<?> responseValueType = getValueTypeIfPossible(responseType);
+        Flowable<?> flowable = builder.rx(RxFlowableInvoker.class).method(name, entity, responseValueType);
         return convert(flowable, responseType);
     }
 
-    private <T> Object convert(Flowable<T> flowable, GenericType<T> responseType) {
+    private <T> Object convert(Flowable<?> flowable, GenericType<T> responseType) {
         Function<Flowable, ?> converter = converters.get(responseType.getRawType());
         return converter.apply(flowable);
+    }
+
+    /**
+     * Jersey has special handling when the invoker response type is javax.ws.rs.core.Response
+     * To maintain that behavior, use the type of the values in the Rx container (in case it is e.g. Single<Response>)
+     * @param responseType
+     * @param <T>
+     * @return
+     */
+    private <T> GenericType getValueTypeIfPossible(GenericType<T> responseType) {
+        if (isConvertibleParameterizedType(responseType)) {
+            return getContainedType((ParameterizedType) responseType.getType());
+        }
+        return responseType;
+    }
+
+    private <T> boolean isConvertibleParameterizedType(GenericType<T> type) {
+        return converters.containsKey(type.getRawType()) && type.getType() instanceof ParameterizedType;
+    }
+
+    private GenericType getContainedType(ParameterizedType type) {
+        return new GenericType(type.getActualTypeArguments()[0]);
     }
 }

--- a/rxjava2-client/src/test/java/FlowableResponseTest.java
+++ b/rxjava2-client/src/test/java/FlowableResponseTest.java
@@ -1,0 +1,52 @@
+import io.reactivex.Flowable;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+
+public class FlowableResponseTest extends RxJerseyTest {
+
+    @Test
+    public void shouldHandleEmpty() {
+        Resource resource = target(Resource.class);
+        Response response = resource.empty().blockingFirst();
+
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void shouldParseEntity() {
+        Resource resource = target(Resource.class);
+        Response response = resource.json("hello").blockingFirst();
+
+        assertEquals(response.readEntity(Entity.class).message, "hello");
+    }
+
+    @Test
+    public void shouldHandleError() {
+        Resource resource = target(Resource.class);
+        Response response = resource.error().blockingFirst();
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Path("/endpoint")
+    public interface Resource {
+
+        @GET
+        @Path("empty")
+        Flowable<Response> empty();
+
+        @GET
+        @Path("json")
+        Flowable<Response> json(@QueryParam("message") String message);
+
+        @GET
+        @Path("error")
+        Flowable<Response> error();
+    }
+}

--- a/rxjava2-client/src/test/java/MaybeResponseTest.java
+++ b/rxjava2-client/src/test/java/MaybeResponseTest.java
@@ -1,0 +1,52 @@
+import io.reactivex.Maybe;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+
+public class MaybeResponseTest extends RxJerseyTest {
+
+    @Test
+    public void shouldHandleEmpty() {
+        Resource resource = target(Resource.class);
+        Response response = resource.empty().blockingGet();
+
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void shouldParseEntity() {
+        Resource resource = target(Resource.class);
+        Response response = resource.json("hello").blockingGet();
+
+        assertEquals(response.readEntity(Entity.class).message, "hello");
+    }
+
+    @Test
+    public void shouldHandleError() {
+        Resource resource = target(Resource.class);
+        Response response = resource.error().blockingGet();
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Path("/endpoint")
+    public interface Resource {
+
+        @GET
+        @Path("empty")
+        Maybe<Response> empty();
+
+        @GET
+        @Path("json")
+        Maybe<Response> json(@QueryParam("message") String message);
+
+        @GET
+        @Path("error")
+        Maybe<Response> error();
+    }
+}

--- a/rxjava2-client/src/test/java/ObservableResponseTest.java
+++ b/rxjava2-client/src/test/java/ObservableResponseTest.java
@@ -1,0 +1,52 @@
+import io.reactivex.Observable;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+
+public class ObservableResponseTest extends RxJerseyTest {
+
+    @Test
+    public void shouldHandleEmpty() {
+        Resource resource = target(Resource.class);
+        Response response = resource.empty().blockingFirst();
+
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void shouldParseEntity() {
+        Resource resource = target(Resource.class);
+        Response response = resource.json("hello").blockingFirst();
+
+        assertEquals(response.readEntity(Entity.class).message, "hello");
+    }
+
+    @Test
+    public void shouldHandleError() {
+        Resource resource = target(Resource.class);
+        Response response = resource.error().blockingFirst();
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Path("/endpoint")
+    public interface Resource {
+
+        @GET
+        @Path("empty")
+        Observable<Response> empty();
+
+        @GET
+        @Path("json")
+        Observable<Response> json(@QueryParam("message") String message);
+
+        @GET
+        @Path("error")
+        Observable<Response> error();
+    }
+}

--- a/rxjava2-client/src/test/java/SingleResponseTest.java
+++ b/rxjava2-client/src/test/java/SingleResponseTest.java
@@ -1,0 +1,52 @@
+import io.reactivex.Single;
+import org.junit.Test;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+
+public class SingleResponseTest extends RxJerseyTest {
+
+    @Test
+    public void shouldHandleEmpty() {
+        Resource resource = target(Resource.class);
+        Response response = resource.empty().blockingGet();
+
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    public void shouldParseEntity() {
+        Resource resource = target(Resource.class);
+        Response response = resource.json("hello").blockingGet();
+
+        assertEquals(response.readEntity(Entity.class).message, "hello");
+    }
+
+    @Test
+    public void shouldHandleError() {
+        Resource resource = target(Resource.class);
+        Response response = resource.error().blockingGet();
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Path("/endpoint")
+    public interface Resource {
+
+        @GET
+        @Path("empty")
+        Single<Response> empty();
+
+        @GET
+        @Path("json")
+        Single<Response> json(@QueryParam("message") String message);
+
+        @GET
+        @Path("error")
+        Single<Response> error();
+    }
+}


### PR DESCRIPTION
Added support for client resources to use Jersey's Response values wrapped in Rx containers.  This is sometimes required when response headers are needed.