### PR TITLE
Support multiple-entry flowables

### DIFF
--- a/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/MaybeInvocationHandler.java
+++ b/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/MaybeInvocationHandler.java
@@ -17,7 +17,7 @@ import java.lang.reflect.Method;
  * Provides {@link InvocationHandler} for resources returning {@code io.reactivex.*} instances
  * and converts them to {@link Maybe}
  */
-public abstract class MaybeInvocationHandler<R> extends RxInvocationHandler<Maybe<?>, Completable, R> {
+abstract class MaybeInvocationHandler<R> extends RxInvocationHandler<Maybe<?>, Completable, R> {
 
     @Inject
     private IterableProvider<CompletableRequestInterceptor> requestInterceptors;

--- a/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/MaybeInvocationHandlerProvider.java
+++ b/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/MaybeInvocationHandlerProvider.java
@@ -1,40 +1,71 @@
 package net.winterly.rxjersey.server.rxjava2;
 
-import io.reactivex.*;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import javax.inject.Inject;
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.server.model.Invocable;
 import org.glassfish.jersey.server.spi.internal.ResourceMethodInvocationHandlerProvider;
-
-import javax.inject.Inject;
-import java.lang.reflect.InvocationHandler;
-import java.util.HashMap;
 
 /**
  * Provides {@link InvocationHandler} for resources returning {@code io.reactivex.*} instances
  * and converts them to {@link Maybe}
  */
-public class MaybeInvocationHandlerProvider implements ResourceMethodInvocationHandlerProvider {
+class MaybeInvocationHandlerProvider implements ResourceMethodInvocationHandlerProvider {
 
-    private final HashMap<Class<?>, Class<? extends InvocationHandler>> handlers = new HashMap<>();
+    private final HashMap<Class<?>, Class<? extends MaybeInvocationHandler<?>>> singleHandlers = new HashMap<>();
 
     @Inject
     private InjectionManager injectionManager;
 
     public MaybeInvocationHandlerProvider() {
-        handlers.put(Flowable.class, FlowableHandler.class);
-        handlers.put(Observable.class, ObservableHandler.class);
-        handlers.put(Single.class, SingleHandler.class);
-        handlers.put(Completable.class, CompletableHandler.class);
-        handlers.put(Maybe.class, MaybeHandler.class);
+        singleHandlers.put(Flowable.class, FlowableHandler.class);
+        singleHandlers.put(Observable.class, ObservableHandler.class);
+        singleHandlers.put(Single.class, SingleHandler.class);
+        singleHandlers.put(Completable.class, CompletableHandler.class);
+        singleHandlers.put(Maybe.class, MaybeHandler.class);
     }
 
     @Override
     public InvocationHandler create(Invocable invocable) {
-        Class<?> returnType = invocable.getRawResponseType();
-        if (handlers.containsKey(returnType)) {
-            return injectionManager.createAndInitialize(handlers.get(returnType));
+        return createInner(invocable, invocable.getRawResponseType(),  (Class<?>) actual(invocable.getResponseType()));
+    }
+
+    private <T, U> InvocationHandler createInner(Invocable invocable, Class<T> returnType, Class<U> innerType) {
+        Streamable streamable = invocable.getHandlingMethod().getAnnotation(Streamable.class);
+        if (streamable == null) {
+            if (singleHandlers.containsKey(returnType)) {
+                return injectionManager.createAndInitialize(singleHandlers.get(returnType));
+            }
+        } else {
+            if (returnType.equals(Flowable.class)) {
+                return createFlowableHandler(streamable);
+            }
         }
         return null;
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private <U> InvocationHandler createFlowableHandler(Streamable streamable) {
+        StreamWriter<U, ?> output = (StreamWriter<U, ?>) injectionManager
+            .createAndInitialize(streamable.writer());
+        return injectionManager.createAndInitialize(StreamableInvocationHandler.class)
+            .setOutput(output);
+    }
+
+    private static Type actual(Type genericType) {
+        if (!(genericType instanceof ParameterizedType)) {
+            return genericType;
+        }
+        final ParameterizedType actualGenericType = (ParameterizedType) genericType;
+        return actualGenericType.getActualTypeArguments()[0];
     }
 
     private static class FlowableHandler extends MaybeInvocationHandler<Flowable<?>> {

--- a/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/PassthroughWriter.java
+++ b/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/PassthroughWriter.java
@@ -1,0 +1,13 @@
+package net.winterly.rxjersey.server.rxjava2;
+
+final class PassthroughWriter extends StreamWriter<Object, Object> {
+
+    PassthroughWriter() {
+        super(Object.class, Object.class, "");
+    }
+
+    @Override
+    protected Object transform(Object input) {
+        return input;
+    }
+}

--- a/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/RxBodyWriter.java
+++ b/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/RxBodyWriter.java
@@ -17,7 +17,7 @@ import javax.inject.Singleton;
  */
 @Singleton
 @Priority(1) //Priority should be higher than JSON providers
-public class RxBodyWriter extends RxGenericBodyWriter {
+class RxBodyWriter extends RxGenericBodyWriter {
     public RxBodyWriter() {
         super(Flowable.class, Observable.class, Single.class, Completable.class, Maybe.class);
     }

--- a/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/StreamWriter.java
+++ b/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/StreamWriter.java
@@ -1,0 +1,138 @@
+package net.winterly.rxjersey.server.rxjava2;
+
+import java.io.IOException;
+import org.glassfish.jersey.server.AsyncContext;
+import org.glassfish.jersey.server.ChunkedOutput;
+
+/**
+ * Responsible for serializing a {@link io.reactivex.Flowable} in a streaming fashion.
+ * Here's a naive JSON example (in practice, it is recommended that you use the streaming
+ * features of a library such as Gson or Jackson for this!):
+ *
+ * <pre>
+ static final class CustomWriter extends StreamWriter&lt;Tuple, String&gt; {
+     CustomWriter() {
+        super(Tuple.class, String.class, "");
+     }
+
+    {@literal @}Override
+     protected String transform(Tuple input) {
+        return String.format("{foo:'%s',bar:'%s'}", input.getFoo(), input.getBar());
+     }
+
+    {@literal @}Override
+     protected void writeChunk(String output, boolean first) throws IOException {
+         if (first) {
+            super.writeChunk("[" + output, true);
+         } else {
+            super.writeChunk("," + output, false);
+         }
+     }
+
+    {@literal @}Override
+     public void writeClose(boolean empty) throws IOException {
+         if (empty) {
+            super.writeChunk("[]", true);
+         } else {
+            super.writeChunk("]", false);
+         }
+     }
+ }
+ * </pre>
+ *
+ * @param <I> The type used in the {@link io.reactivex.Flowable}.
+ * @param <O> The type to pass to {@link ChunkedOutput}. This will then be processed by
+ *           the matching {@link javax.ws.rs.ext.MessageBodyWriter}. Unfortunately, this has
+ *           to be shared by every chunk written (you can't mix and match chunk types).
+ */
+public abstract class StreamWriter<I, O> implements AutoCloseable {
+
+    private final Class<I> streamType;
+    private final Class<O> chunkType;
+    private final ChunkedOutput<O> chunkedOutput;
+
+    private volatile boolean first = true;
+
+    /**
+     * @param streamType The type used in the {@link io.reactivex.Flowable}.
+     * @param chunkType The type to pass to {@link ChunkedOutput}. This will then be processed by
+     *                  the matching {@link javax.ws.rs.ext.MessageBodyWriter}. Unfortunately, this has
+     *                  to be shared by every chunk written (you can't mix and match chunk types).
+     * @param delimiter A delimiter string to output between chunks. This will always be inserted
+     *                  after every chunk so is not suitable for strict comma separation, for example.
+     */
+    protected StreamWriter(Class<I> streamType,
+                           Class<O> chunkType,
+                           String delimiter) {
+        this.streamType = streamType;
+        this.chunkType = chunkType;
+        this.chunkedOutput = new ChunkedOutput<>(chunkType, delimiter);
+    }
+
+    /**
+     * Converts from the stream type to the chunk type.
+     *
+     * @param input The stream object.
+     * @return The chunk object.
+     */
+    protected abstract O transform(I input);
+
+    /**
+     * Invoked to write the chunk out to the client. Can be overriden to insert additional
+     * processing before and after. By default the chunk is just passed directly.
+     *
+     * @param output The chunk object.
+     * @param first True if this is the first chunk.
+     * @throws IOException On exceptions writing out the chunk.
+     */
+    protected void writeChunk(O output, boolean first) throws IOException {
+        chunkedOutput.write(output);
+    }
+
+    /**
+     * Invoked if an error occurs processing the stream. Does nothing by default.
+     *
+     * @param cause The cause of the error.
+     */
+    void error(Throwable cause) {
+        // No-op
+    }
+
+    /**
+     * Invoked before the stream is closed. Can be used to write additional footer
+     * data. Does nothing by default.
+     *
+     * @param empty True if no chunks were written.
+     * @throws IOException On exceptions writing out the chunk.
+     */
+    protected void beforeClose(boolean empty) throws IOException {
+        // No-op
+    }
+
+    final void write(I input) throws IOException {
+        O output = transform(input);
+        boolean firstNow = first;
+        if (first) {
+            synchronized (this) {
+                firstNow = first;
+                if (firstNow) {
+                    first = false;
+                }
+            }
+        }
+        writeChunk(output, firstNow);
+    }
+
+    void resumeFor(AsyncContext asyncContext) {
+        asyncContext.resume(chunkedOutput);
+    }
+
+    @Override
+    public final void close() throws IOException {
+        try {
+            beforeClose(first);
+        } finally {
+            chunkedOutput.close();
+        }
+    }
+}

--- a/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/Streamable.java
+++ b/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/Streamable.java
@@ -1,0 +1,27 @@
+package net.winterly.rxjersey.server.rxjava2;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the method returns an RX {@link io.reactivex.Flowable} with multiple elements
+ * which should be streamed back to the client as they are received. Without this annotation, any
+ * more than a single element will be treated as an error condition.
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Streamable {
+
+  /**
+   * By default, each object in the flowable will be serialised with whatever {@link
+   * javax.ws.rs.ext.MessageBodyWriter} is selected by JAX-RS, then immediately flushed to the
+   * client. However, this is usually only suitable for simple data formats such as CSV. For more
+   * complex formats, you will need to define a {@link StreamWriter}.
+   *
+   * @return The stream writer.
+   */
+  Class<? extends StreamWriter<?, ?>> writer() default PassthroughWriter.class;
+
+}

--- a/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/StreamableInvocationHandler.java
+++ b/rxjava2-server/src/main/java/net/winterly/rxjersey/server/rxjava2/StreamableInvocationHandler.java
@@ -1,0 +1,78 @@
+package net.winterly.rxjersey.server.rxjava2;
+
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Maybe;
+import io.reactivex.schedulers.Schedulers;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.util.function.Consumer;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import net.winterly.rxjersey.server.RxInvocationHandler;
+import org.glassfish.hk2.api.IterableProvider;
+
+/**
+ * Provides {@link InvocationHandler} for resources returning {@code io.reactivex.*} instances
+ * and converts them to {@link Maybe}
+ */
+class StreamableInvocationHandler<I, O> extends RxInvocationHandler<Flowable<I>, Completable, Flowable<I>> {
+
+    @Inject
+    private IterableProvider<CompletableRequestInterceptor> requestInterceptors;
+
+    private StreamWriter<I, O> output;
+    private Consumer<String> infoLogger = System.out::println;
+    private Consumer<Throwable> errorLogger = Throwable::printStackTrace;
+
+    StreamableInvocationHandler<I, O> setOutput(StreamWriter<I, O> output) {
+        this.output = output;
+        return this;
+    }
+
+    StreamableInvocationHandler<I, O> setErrorLogger(Consumer<Throwable> errorLogger) {
+        this.errorLogger = errorLogger;
+        return this;
+    }
+
+    StreamableInvocationHandler<I, O> setInfoLogger(Consumer<String> infoLogger) {
+        this.infoLogger = infoLogger;
+        return this;
+    }
+
+    @Override
+    protected Flowable<I> convert(Flowable<I> result) {
+      throw new UnsupportedOperationException();
+    }
+
+  @Override
+    @SuppressWarnings("unchecked")
+    public Object invoke(Object proxy, Method method, Object[] args) {
+        infoLogger.accept("Setting up async request");
+        org.glassfish.jersey.server.AsyncContext asyncContext = suspend();
+        final ContainerRequestContext requestContext = requestContextProvider.get();
+        Flowable.fromIterable(requestInterceptors)
+            .flatMapCompletable(interceptor -> interceptor.intercept(requestContext))
+            .subscribeOn(Schedulers.computation())
+            .subscribe(() -> {
+                infoLogger.accept("Processed interceptors");
+                Flowable<I> flowable = (Flowable<I>) method.invoke(proxy, args);
+                flowable.subscribe(
+                    output::write,
+                    e -> {
+                        errorLogger.accept(e);
+                        output.error(e);
+                        output.close();
+                    },
+                    output::close);
+                output.resumeFor(asyncContext);
+                infoLogger.accept("Handed off for chunked processing");
+            }, e -> {
+                errorLogger.accept(new RuntimeException("Error streaming data", e));
+                asyncContext.resume(e);
+            });
+        infoLogger.accept("Work submitted");
+        return null; //async methods return nulls
+    }
+
+}

--- a/rxjava2-server/src/test/java/RxJerseyTest.java
+++ b/rxjava2-server/src/test/java/RxJerseyTest.java
@@ -9,7 +9,8 @@ public class RxJerseyTest extends JerseyTest {
     protected ResourceConfig config() {
         return new ResourceConfig()
                 .register(JacksonFeature.class)
-                .register(RxJerseyServerFeature.class);
+                .register(RxJerseyServerFeature.class)
+                .register(TupleMessageBodyWriter.class);
     }
 
     @Override

--- a/rxjava2-server/src/test/java/Tuple.java
+++ b/rxjava2-server/src/test/java/Tuple.java
@@ -1,0 +1,25 @@
+public final class Tuple {
+    private String foo;
+    private String bar;
+
+    Tuple(int i) {
+        this.foo = "foo" + i;
+        this.bar = "bar" + i;
+    }
+
+    @Override
+    public String toString() {
+        return "{" +
+            "foo:'" + foo + '\'' +
+            ",bar:'" + bar + '\'' +
+            '}';
+    }
+
+    public String getBar() {
+        return bar;
+    }
+
+    public String getFoo() {
+        return foo;
+    }
+}

--- a/rxjava2-server/src/test/java/TupleMessageBodyWriter.java
+++ b/rxjava2-server/src/test/java/TupleMessageBodyWriter.java
@@ -1,0 +1,26 @@
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import javafx.scene.SnapshotParameters;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.GenericEntity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+
+public class TupleMessageBodyWriter implements MessageBodyWriter<Tuple> {
+
+  @Override
+  public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+    return type.equals(Tuple.class) && mediaType.equals(MediaType.TEXT_HTML_TYPE);
+  }
+
+  @Override
+  public void writeTo(Tuple tuple, Class<?> type, Type genericType, Annotation[] annotations,
+      MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+      throws IOException {
+    entityStream.write(tuple.toString().getBytes(StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
Been playing around with some RX patterns and wondered if this was possible in a generic way. Turns out it is, sort of.

With these changes, the following spits out each item as a string on a new line as the items arrive, all using async:
```
        @GET
        @Path("stringStream")
        @Streamable // Activates the new code
        public Flowable<String> stringStream() {
            return Flowable.range(1, 49)
                .zipWith(Flowable.interval(1, SECOND), (it, interval) -> it)
                .map(i -> "Item " + i + "\n");
        }
```
What I've put together is also compatible with Jackson's `JsonCreator`, so you can just use `@Streamable(writer = SomeCustomWriter.class` and call `JsonCreator` from there:
```
        @GET
        @Path("objectStream")
        @Streamable(writer = SomeCustomWriter.class)
        public Flowable<Tuple> objectStream() {
            return Flowable.range(1, 49)
                .zipWith(Flowable.interval(1, SECOND), (it, interval) -> it)
                .map(Tuple::new);
        }
```
Not sure it's perfect, and I need to test it a while lot more, but I thought I'd pop it here here for thoughts.
