### PR TITLE
support registration for client that mixes rx and non-rx return types

### DIFF
--- a/rxjava2-client/src/main/java/net/winterly/rxjersey/client/rxjava2/FlowableClientMethodInvoker.java
+++ b/rxjava2-client/src/main/java/net/winterly/rxjersey/client/rxjava2/FlowableClientMethodInvoker.java
@@ -25,6 +25,9 @@ public class FlowableClientMethodInvoker implements ClientMethodInvoker<Object> 
 
     @Override
     public <T> Object method(Invocation.Builder builder, String name, GenericType<T> responseType) {
+        if (!isConvertibleType(responseType)) {
+            return builder.method(name, responseType);
+        }
         GenericType<?> responseValueType = getValueTypeIfPossible(responseType);
         Flowable<?> flowable = builder.rx(RxFlowableInvoker.class).method(name, responseValueType);
         return convert(flowable, responseType);
@@ -32,6 +35,9 @@ public class FlowableClientMethodInvoker implements ClientMethodInvoker<Object> 
 
     @Override
     public <T> Object method(Invocation.Builder builder, String name, Entity<?> entity, GenericType<T> responseType) {
+        if (!isConvertibleType(responseType)) {
+            return builder.method(name, entity, responseType);
+        }
         GenericType<?> responseValueType = getValueTypeIfPossible(responseType);
         Flowable<?> flowable = builder.rx(RxFlowableInvoker.class).method(name, entity, responseValueType);
         return convert(flowable, responseType);
@@ -57,7 +63,11 @@ public class FlowableClientMethodInvoker implements ClientMethodInvoker<Object> 
     }
 
     private <T> boolean isConvertibleParameterizedType(GenericType<T> type) {
-        return converters.containsKey(type.getRawType()) && type.getType() instanceof ParameterizedType;
+        return isConvertibleType(type) && type.getType() instanceof ParameterizedType;
+    }
+
+    private <T> boolean isConvertibleType(GenericType<T> type) {
+        return converters.containsKey(type.getRawType());
     }
 
     private GenericType getContainedType(ParameterizedType type) {

--- a/rxjava2-client/src/test/java/FlowableResourceTest.java
+++ b/rxjava2-client/src/test/java/FlowableResourceTest.java
@@ -12,7 +12,7 @@ public class FlowableResourceTest extends RxJerseyTest {
 
     @Test
     public void shouldReturnContent() {
-        ObservableResource resource = target(ObservableResource.class);
+        Resource resource = target(Resource.class);
         String message = resource.echo("hello").blockingFirst();
 
         assertEquals("hello", message);
@@ -20,7 +20,7 @@ public class FlowableResourceTest extends RxJerseyTest {
 
     @Test
     public void shouldReturnNoContentOnNull() {
-        ObservableResource resource = target(ObservableResource.class);
+        Resource resource = target(Resource.class);
         String message = resource.empty().blockingFirst();
 
         assertEquals("", message);
@@ -28,14 +28,30 @@ public class FlowableResourceTest extends RxJerseyTest {
 
     @Test(expected = BadRequestException.class)
     public void shouldHandleError() {
-        ObservableResource resource = target(ObservableResource.class);
+        Resource resource = target(Resource.class);
         String message = resource.error().blockingFirst();
 
         assertEquals("", message);
     }
 
+    @Test
+    public void shouldReturnContentForNonRxTypes() {
+        Resource resource = target(Resource.class);
+        String message = resource.string();
+
+        assertEquals("string", message);
+    }
+
+    @Test
+    public void shouldReturnContentForNonRxTypesWithParam() {
+        Resource resource = target(Resource.class);
+        Entity entity = resource.json("message");
+
+        assertEquals("message", entity.message);
+    }
+
     @Path("/endpoint")
-    public interface ObservableResource {
+    public interface Resource {
 
         @GET
         @Path("echo")
@@ -48,5 +64,13 @@ public class FlowableResourceTest extends RxJerseyTest {
         @GET
         @Path("error")
         Flowable<String> error();
+
+        @GET
+        @Path("string")
+        String string();
+
+        @GET
+        @Path("json")
+        Entity json(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/FlowableResponseTest.java
+++ b/rxjava2-client/src/test/java/FlowableResponseTest.java
@@ -34,6 +34,22 @@ public class FlowableResponseTest extends RxJerseyTest {
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
+    @Test
+    public void shouldReturnContentForNonRxTypes() {
+        Resource resource = target(Resource.class);
+        Response response = resource.string();
+
+        assertEquals("string", response.readEntity(String.class));
+    }
+
+    @Test
+    public void shouldReturnContentForNonRxTypesWithParam() {
+        Resource resource = target(Resource.class);
+        Response response = resource.echo("message");
+
+        assertEquals("message", response.readEntity(String.class));
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +64,13 @@ public class FlowableResponseTest extends RxJerseyTest {
         @GET
         @Path("error")
         Flowable<Response> error();
+
+        @GET
+        @Path("string")
+        Response string();
+
+        @GET
+        @Path("echo")
+        Response echo(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/MaybeResourceTest.java
+++ b/rxjava2-client/src/test/java/MaybeResourceTest.java
@@ -34,6 +34,22 @@ public class MaybeResourceTest extends RxJerseyTest {
         assertEquals("", message);
     }
 
+    @Test
+    public void shouldReturnContentForNonRxTypes() {
+        Resource resource = target(Resource.class);
+        String message = resource.string();
+
+        assertEquals("string", message);
+    }
+
+    @Test
+    public void shouldReturnContentForNonRxTypesWithParam() {
+        Resource resource = target(Resource.class);
+        Entity entity = resource.json("message");
+
+        assertEquals("message", entity.message);
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +64,13 @@ public class MaybeResourceTest extends RxJerseyTest {
         @GET
         @Path("error")
         Maybe<String> error();
+
+        @GET
+        @Path("string")
+        String string();
+
+        @GET
+        @Path("json")
+        Entity json(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/MaybeResponseTest.java
+++ b/rxjava2-client/src/test/java/MaybeResponseTest.java
@@ -34,6 +34,22 @@ public class MaybeResponseTest extends RxJerseyTest {
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
+    @Test
+    public void shouldReturnContentForNonRxTypes() {
+        Resource resource = target(Resource.class);
+        Response response = resource.string();
+
+        assertEquals("string", response.readEntity(String.class));
+    }
+
+    @Test
+    public void shouldReturnContentForNonRxTypesWithParam() {
+        Resource resource = target(Resource.class);
+        Response response = resource.echo("message");
+
+        assertEquals("message", response.readEntity(String.class));
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +64,13 @@ public class MaybeResponseTest extends RxJerseyTest {
         @GET
         @Path("error")
         Maybe<Response> error();
+
+        @GET
+        @Path("string")
+        Response string();
+
+        @GET
+        @Path("echo")
+        Response echo(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/ObservableResourceTest.java
+++ b/rxjava2-client/src/test/java/ObservableResourceTest.java
@@ -34,6 +34,22 @@ public class ObservableResourceTest extends RxJerseyTest {
         assertEquals("", message);
     }
 
+    @Test
+    public void shouldReturnContentForNonRxTypes() {
+        Resource resource = target(Resource.class);
+        String message = resource.string();
+
+        assertEquals("string", message);
+    }
+
+    @Test
+    public void shouldReturnContentForNonRxTypesWithParam() {
+        Resource resource = target(Resource.class);
+        Entity entity = resource.json("message");
+
+        assertEquals("message", entity.message);
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +64,13 @@ public class ObservableResourceTest extends RxJerseyTest {
         @GET
         @Path("error")
         Observable<String> error();
+
+        @GET
+        @Path("string")
+        String string();
+
+        @GET
+        @Path("json")
+        Entity json(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/ObservableResponseTest.java
+++ b/rxjava2-client/src/test/java/ObservableResponseTest.java
@@ -34,6 +34,22 @@ public class ObservableResponseTest extends RxJerseyTest {
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
+    @Test
+    public void shouldReturnContentForNonRxTypes() {
+        Resource resource = target(Resource.class);
+        Response response = resource.string();
+
+        assertEquals("string", response.readEntity(String.class));
+    }
+
+    @Test
+    public void shouldReturnContentForNonRxTypesWithParam() {
+        Resource resource = target(Resource.class);
+        Response response = resource.echo("message");
+
+        assertEquals("message", response.readEntity(String.class));
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +64,13 @@ public class ObservableResponseTest extends RxJerseyTest {
         @GET
         @Path("error")
         Observable<Response> error();
+
+        @GET
+        @Path("string")
+        Response string();
+
+        @GET
+        @Path("echo")
+        Response echo(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/RxJerseyTest.java
+++ b/rxjava2-client/src/test/java/RxJerseyTest.java
@@ -97,6 +97,12 @@ public class RxJerseyTest extends JerseyTest {
             throw new BadRequestException();
         }
 
+        @GET
+        @Path("string")
+        public String string() {
+            return "string";
+        }
+
         @Path("subresource/{id}")
         public ServerSubResource subResource(@PathParam("id") String id) {
             return new ServerSubResource(id);

--- a/rxjava2-client/src/test/java/SingleResourceTest.java
+++ b/rxjava2-client/src/test/java/SingleResourceTest.java
@@ -34,6 +34,22 @@ public class SingleResourceTest extends RxJerseyTest {
         assertEquals("", message);
     }
 
+    @Test
+    public void shouldReturnContentForNonRxTypes() {
+        Resource resource = target(Resource.class);
+        String message = resource.string();
+
+        assertEquals("string", message);
+    }
+
+    @Test
+    public void shouldReturnContentForNonRxTypesWithParam() {
+        Resource resource = target(Resource.class);
+        Entity entity = resource.json("message");
+
+        assertEquals("message", entity.message);
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +64,13 @@ public class SingleResourceTest extends RxJerseyTest {
         @GET
         @Path("error")
         Single<String> error();
+
+        @GET
+        @Path("string")
+        String string();
+
+        @GET
+        @Path("json")
+        Entity json(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/SingleResponseTest.java
+++ b/rxjava2-client/src/test/java/SingleResponseTest.java
@@ -34,6 +34,22 @@ public class SingleResponseTest extends RxJerseyTest {
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
+    @Test
+    public void shouldReturnContentForNonRxTypes() {
+        Resource resource = target(Resource.class);
+        Response response = resource.string();
+
+        assertEquals("string", response.readEntity(String.class));
+    }
+
+    @Test
+    public void shouldReturnContentForNonRxTypesWithParam() {
+        Resource resource = target(Resource.class);
+        Response response = resource.echo("message");
+
+        assertEquals("message", response.readEntity(String.class));
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +64,13 @@ public class SingleResponseTest extends RxJerseyTest {
         @GET
         @Path("error")
         Single<Response> error();
+
+        @GET
+        @Path("string")
+        Response string();
+
+        @GET
+        @Path("echo")
+        Response echo(@QueryParam("message") String message);
     }
 }


### PR DESCRIPTION
Currently when constructing a client using FlowableClientMethodInvoker, calls fail for any non-Rx types due to an NPE caused by the below lines, since converters are only registered for Rx classes:

`Function<Flowable, ?> converter = converters.get(responseType.getRawType());`
`return converter.apply(flowable); `

Implement short-circuiting of any non-rx method invocations to allow both Rx and non-Rx return types to be registered on the same client.