### PR TITLE
support registration for client that mixes rx and non-rx return types

### DIFF
--- a/rxjava2-client/src/main/java/net/winterly/rxjersey/client/rxjava2/CompositeClientMethodInvoker.java
+++ b/rxjava2-client/src/main/java/net/winterly/rxjersey/client/rxjava2/CompositeClientMethodInvoker.java
@@ -1,0 +1,37 @@
+package net.winterly.rxjersey.client.rxjava2;
+
+import net.winterly.rxjersey.client.ClientMethodInvoker;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.GenericType;
+
+public class CompositeClientMethodInvoker implements ClientMethodInvoker<Object> {
+
+    private final FlowableClientMethodInvoker flowableClientMethodInvoker;
+    private final SyncClientMethodInvoker syncClientMethodInvoker;
+
+    public CompositeClientMethodInvoker() {
+        this.flowableClientMethodInvoker = new FlowableClientMethodInvoker();
+        this.syncClientMethodInvoker = new SyncClientMethodInvoker();
+    }
+
+    @Override
+    public <T> Object method(final Invocation.Builder builder, final String name, final GenericType<T> responseType) {
+        return isSupportedByFlowableInvoker(responseType)
+                ? flowableClientMethodInvoker.method(builder, name, responseType)
+                : syncClientMethodInvoker.method(builder, name, responseType);
+    }
+
+    @Override
+    public <T> Object method(final Invocation.Builder builder, final String name, final Entity<?> entity, final GenericType<T> responseType) {
+        return isSupportedByFlowableInvoker(responseType)
+                ? flowableClientMethodInvoker.method(builder, name, entity, responseType)
+                : syncClientMethodInvoker.method(builder, name, entity, responseType);
+    }
+
+    private <T> boolean isSupportedByFlowableInvoker(final GenericType<T> responseType) {
+        return flowableClientMethodInvoker.supportedTypes().contains(responseType.getRawType());
+    }
+
+}

--- a/rxjava2-client/src/main/java/net/winterly/rxjersey/client/rxjava2/SyncClientMethodInvoker.java
+++ b/rxjava2-client/src/main/java/net/winterly/rxjersey/client/rxjava2/SyncClientMethodInvoker.java
@@ -1,0 +1,20 @@
+package net.winterly.rxjersey.client.rxjava2;
+
+import net.winterly.rxjersey.client.ClientMethodInvoker;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.GenericType;
+
+public class SyncClientMethodInvoker implements ClientMethodInvoker<Object> {
+
+    @Override
+    public <T> Object method(final Invocation.Builder builder, final String name, final GenericType<T> responseType) {
+        return builder.method(name, responseType);
+    }
+
+    @Override
+    public <T> Object method(final Invocation.Builder builder, final String name, final Entity<?> entity, final GenericType<T> responseType) {
+        return builder.method(name, entity, responseType);
+    }
+}

--- a/rxjava2-client/src/test/java/CompositeResourceTest.java
+++ b/rxjava2-client/src/test/java/CompositeResourceTest.java
@@ -1,0 +1,84 @@
+import io.reactivex.Flowable;
+import net.winterly.rxjersey.client.WebResourceFactory;
+import net.winterly.rxjersey.client.rxjava2.CompositeClientMethodInvoker;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+
+public class CompositeResourceTest extends RxJerseyTest {
+
+    @Override
+    protected <T> T target(final Class<T> resource) {
+        return WebResourceFactory.newResource(resource, target(), new CompositeClientMethodInvoker());
+    }
+
+    @Test
+    public void shouldReturnContent() {
+        final CompositeResource resource = target(CompositeResource.class);
+        final String message = resource.echo("hello").blockingFirst();
+
+        assertEquals("hello", message);
+    }
+
+    @Test
+    public void shouldReturnNoContentOnNull() {
+        final CompositeResource resource = target(CompositeResource.class);
+        final String message = resource.empty().blockingFirst();
+
+        assertEquals("", message);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldHandleError() {
+        final CompositeResource resource = target(CompositeResource.class);
+        final String message = resource.error().blockingFirst();
+
+        assertEquals("", message);
+    }
+
+    @Test
+    public void shouldReturnContentForNonRxType() {
+        final CompositeResource resource = target(CompositeResource.class);
+        final String message = resource.string();
+
+        assertEquals("string", message);
+    }
+
+    @Test
+    public void shouldReturnContentForNonRxResponse() {
+        final CompositeResource resource = target(CompositeResource.class);
+        final Response response = resource.json("message");
+
+        assertEquals("message", response.readEntity(Entity.class).message);
+    }
+
+    @Path("/endpoint")
+    public interface CompositeResource {
+
+        @GET
+        @Path("echo")
+        Flowable<String> echo(@QueryParam("message") String message);
+
+        @GET
+        @Path("empty")
+        Flowable<String> empty();
+
+        @GET
+        @Path("error")
+        Flowable<String> error();
+
+        @GET
+        @Path("string")
+        String string();
+
+        @GET
+        @Path("json")
+        Response json(@QueryParam("message") String message);
+    }
+}

--- a/rxjava2-client/src/test/java/FlowableResourceTest.java
+++ b/rxjava2-client/src/test/java/FlowableResourceTest.java
@@ -2,6 +2,7 @@ import io.reactivex.Flowable;
 import org.junit.Test;
 
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -12,7 +13,7 @@ public class FlowableResourceTest extends RxJerseyTest {
 
     @Test
     public void shouldReturnContent() {
-        ObservableResource resource = target(ObservableResource.class);
+        Resource resource = target(Resource.class);
         String message = resource.echo("hello").blockingFirst();
 
         assertEquals("hello", message);
@@ -20,7 +21,7 @@ public class FlowableResourceTest extends RxJerseyTest {
 
     @Test
     public void shouldReturnNoContentOnNull() {
-        ObservableResource resource = target(ObservableResource.class);
+        Resource resource = target(Resource.class);
         String message = resource.empty().blockingFirst();
 
         assertEquals("", message);
@@ -28,14 +29,30 @@ public class FlowableResourceTest extends RxJerseyTest {
 
     @Test(expected = BadRequestException.class)
     public void shouldHandleError() {
-        ObservableResource resource = target(ObservableResource.class);
+        Resource resource = target(Resource.class);
         String message = resource.error().blockingFirst();
 
         assertEquals("", message);
     }
 
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxType() {
+        Resource resource = target(Resource.class);
+        String message = resource.string();
+
+        assertEquals("", message);
+    }
+
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxTypeWithParam() {
+        Resource resource = target(Resource.class);
+        Entity entity = resource.json("message");
+
+        assertEquals("", entity.message);
+    }
+
     @Path("/endpoint")
-    public interface ObservableResource {
+    public interface Resource {
 
         @GET
         @Path("echo")
@@ -48,5 +65,13 @@ public class FlowableResourceTest extends RxJerseyTest {
         @GET
         @Path("error")
         Flowable<String> error();
+
+        @GET
+        @Path("string")
+        String string();
+
+        @GET
+        @Path("json")
+        Entity json(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/FlowableResponseTest.java
+++ b/rxjava2-client/src/test/java/FlowableResponseTest.java
@@ -1,6 +1,7 @@
 import io.reactivex.Flowable;
 import org.junit.Test;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -34,6 +35,22 @@ public class FlowableResponseTest extends RxJerseyTest {
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxType() {
+        Resource resource = target(Resource.class);
+        Response response = resource.string();
+
+        assertEquals(response.readEntity(String.class), "");
+    }
+
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxTypeWithParam() {
+        Resource resource = target(Resource.class);
+        Response response = resource.echo("message");
+
+        assertEquals(response.readEntity(String.class), "");
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +65,14 @@ public class FlowableResponseTest extends RxJerseyTest {
         @GET
         @Path("error")
         Flowable<Response> error();
+
+        @GET
+        @Path("string")
+        Response string();
+
+        @GET
+        @Path("echo")
+        Response echo(@QueryParam("message") String message);
+
     }
 }

--- a/rxjava2-client/src/test/java/MaybeResourceTest.java
+++ b/rxjava2-client/src/test/java/MaybeResourceTest.java
@@ -1,6 +1,7 @@
 import io.reactivex.Maybe;
 import org.junit.Test;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -34,6 +35,22 @@ public class MaybeResourceTest extends RxJerseyTest {
         assertEquals("", message);
     }
 
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxType() {
+        Resource resource = target(Resource.class);
+        String message = resource.string();
+
+        assertEquals("", message);
+    }
+
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxTypeWithParam() {
+        Resource resource = target(Resource.class);
+        Entity entity = resource.json("message");
+
+        assertEquals("", entity.message);
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +65,13 @@ public class MaybeResourceTest extends RxJerseyTest {
         @GET
         @Path("error")
         Maybe<String> error();
+
+        @GET
+        @Path("string")
+        String string();
+
+        @GET
+        @Path("json")
+        Entity json(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/MaybeResponseTest.java
+++ b/rxjava2-client/src/test/java/MaybeResponseTest.java
@@ -1,6 +1,7 @@
 import io.reactivex.Maybe;
 import org.junit.Test;
 
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -34,6 +35,22 @@ public class MaybeResponseTest extends RxJerseyTest {
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxType() {
+        Resource resource = target(Resource.class);
+        Response response = resource.string();
+
+        assertEquals(response.readEntity(String.class), "");
+    }
+
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxTypeWithParam() {
+        Resource resource = target(Resource.class);
+        Response response = resource.echo("message");
+
+        assertEquals(response.readEntity(String.class), "");
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +65,14 @@ public class MaybeResponseTest extends RxJerseyTest {
         @GET
         @Path("error")
         Maybe<Response> error();
+
+        @GET
+        @Path("string")
+        Response string();
+
+        @GET
+        @Path("echo")
+        Response echo(@QueryParam("message") String message);
+
     }
 }

--- a/rxjava2-client/src/test/java/ObservableResourceTest.java
+++ b/rxjava2-client/src/test/java/ObservableResourceTest.java
@@ -2,6 +2,7 @@ import io.reactivex.Observable;
 import org.junit.Test;
 
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -34,6 +35,22 @@ public class ObservableResourceTest extends RxJerseyTest {
         assertEquals("", message);
     }
 
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxType() {
+        Resource resource = target(Resource.class);
+        String message = resource.string();
+
+        assertEquals("", message);
+    }
+
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxTypeWithParam() {
+        Resource resource = target(Resource.class);
+        Entity entity = resource.json("message");
+
+        assertEquals("", entity.message);
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +65,13 @@ public class ObservableResourceTest extends RxJerseyTest {
         @GET
         @Path("error")
         Observable<String> error();
+
+        @GET
+        @Path("string")
+        String string();
+
+        @GET
+        @Path("json")
+        Entity json(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/ObservableResponseTest.java
+++ b/rxjava2-client/src/test/java/ObservableResponseTest.java
@@ -2,6 +2,7 @@ import io.reactivex.Observable;
 import org.junit.Test;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
@@ -34,6 +35,22 @@ public class ObservableResponseTest extends RxJerseyTest {
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxType() {
+        Resource resource = target(Resource.class);
+        Response response = resource.string();
+
+        assertEquals(response.readEntity(String.class), "");
+    }
+
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxTypeWithParam() {
+        Resource resource = target(Resource.class);
+        Response response = resource.echo("message");
+
+        assertEquals(response.readEntity(String.class), "");
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +65,13 @@ public class ObservableResponseTest extends RxJerseyTest {
         @GET
         @Path("error")
         Observable<Response> error();
+
+        @GET
+        @Path("string")
+        Response string();
+
+        @GET
+        @Path("echo")
+        Response echo(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/RxJerseyTest.java
+++ b/rxjava2-client/src/test/java/RxJerseyTest.java
@@ -97,6 +97,12 @@ public class RxJerseyTest extends JerseyTest {
             throw new BadRequestException();
         }
 
+        @GET
+        @Path("string")
+        public String string() {
+            return "string";
+        }
+
         @Path("subresource/{id}")
         public ServerSubResource subResource(@PathParam("id") String id) {
             return new ServerSubResource(id);

--- a/rxjava2-client/src/test/java/SingleResourceTest.java
+++ b/rxjava2-client/src/test/java/SingleResourceTest.java
@@ -2,6 +2,7 @@ import io.reactivex.Single;
 import org.junit.Test;
 
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -34,6 +35,22 @@ public class SingleResourceTest extends RxJerseyTest {
         assertEquals("", message);
     }
 
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxType() {
+        Resource resource = target(Resource.class);
+        String message = resource.string();
+
+        assertEquals("", message);
+    }
+
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxTypeWithParam() {
+        Resource resource = target(Resource.class);
+        Entity entity = resource.json("message");
+
+        assertEquals("", entity.message);
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +65,13 @@ public class SingleResourceTest extends RxJerseyTest {
         @GET
         @Path("error")
         Single<String> error();
+
+        @GET
+        @Path("string")
+        String string();
+
+        @GET
+        @Path("json")
+        Entity json(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/SingleResponseTest.java
+++ b/rxjava2-client/src/test/java/SingleResponseTest.java
@@ -2,6 +2,7 @@ import io.reactivex.Single;
 import org.junit.Test;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.NotSupportedException;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
@@ -34,6 +35,22 @@ public class SingleResponseTest extends RxJerseyTest {
         assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
     }
 
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxType() {
+        Resource resource = target(Resource.class);
+        Response response = resource.string();
+
+        assertEquals(response.readEntity(String.class), "");
+    }
+
+    @Test(expected = NotSupportedException.class)
+    public void shouldThrowSensibleErrorForNonRxTypeWithParam() {
+        Resource resource = target(Resource.class);
+        Response response = resource.echo("message");
+
+        assertEquals(response.readEntity(String.class), "");
+    }
+
     @Path("/endpoint")
     public interface Resource {
 
@@ -48,5 +65,13 @@ public class SingleResponseTest extends RxJerseyTest {
         @GET
         @Path("error")
         Single<Response> error();
+
+        @GET
+        @Path("string")
+        Response string();
+
+        @GET
+        @Path("echo")
+        Response echo(@QueryParam("message") String message);
     }
 }

--- a/rxjava2-client/src/test/java/SyncResourceTest.java
+++ b/rxjava2-client/src/test/java/SyncResourceTest.java
@@ -1,0 +1,73 @@
+import net.winterly.rxjersey.client.WebResourceFactory;
+import net.winterly.rxjersey.client.rxjava2.SyncClientMethodInvoker;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import static org.junit.Assert.assertEquals;
+
+public class SyncResourceTest extends RxJerseyTest {
+
+    @Override
+    protected <T> T target(Class<T> resource) {
+        return WebResourceFactory.newResource(resource, target(), new SyncClientMethodInvoker());
+    }
+
+    @Test
+    public void shouldReturnContentForResponse() {
+        SyncResource resource = target(SyncResource.class);
+        Response response = resource.echo("hello");
+
+        assertEquals("hello", response.readEntity(String.class));
+    }
+
+    @Test
+    public void shouldReturnNoContentOnNull() {
+        SyncResource resource = target(SyncResource.class);
+        String message = resource.empty();
+
+        assertEquals("", message);
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void shouldHandleError() {
+        SyncResource resource = target(SyncResource.class);
+        String message = resource.error();
+
+        assertEquals("", message);
+    }
+
+    @Test
+    public void shouldReturnJsonContent() {
+        SyncResource resource = target(SyncResource.class);
+        Entity entity = resource.json("message");
+
+        assertEquals("message", entity.message);
+    }
+
+
+    @Path("/endpoint")
+    public interface SyncResource {
+
+        @GET
+        @Path("echo")
+        Response echo(@QueryParam("message") String message);
+
+        @GET
+        @Path("empty")
+        String empty();
+
+        @GET
+        @Path("error")
+        String error();
+
+        @GET
+        @Path("json")
+        Entity json(@QueryParam("message") String message);
+    }
+
+}


### PR DESCRIPTION
Currently when constructing a client using FlowableClientMethodInvoker, calls fail for any non-Rx types due to an NPE caused by the below lines, since converters are only registered for Rx classes:

`Function<Flowable, ?> converter = converters.get(responseType.getRawType());`
`return converter.apply(flowable); `

This review adds new method invokers so developers can register invokers which support both Rx and non-Rx return types to be registered on the same client. This is in comparison with [pull request 19](https://github.com/alex-shpak/rx-jersey/pull/19) which I also submitted, which takes a different approach and supports the mixing within the FlowableClientMethodInvoker itself. Wasn't sure which approach you'd prefer, so submitted both options.